### PR TITLE
Add "files" entry to only deploy select files

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,13 @@
   "directories": {
     "lib": "./lib"
   },
+  "files": [
+    "lib",
+    "LICENSE.BSD",
+    "LICENSE.closure-compiler",
+    "LICENSE.esprima",
+    "README.md"
+  ],
   "maintainers": [
     {
       "name": "Yusuke Suzuki",


### PR DESCRIPTION
This adds a [files](https://docs.npmjs.com/files/package.json#files) entry to package.json so that it the npm package only contains needed files.