### PR TITLE
point to gh-pages doctrine.js

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -10,7 +10,7 @@
 
     <script type="text/javascript" charset="utf-8" src="../javascripts/jquery.min.js"></script>
     <script type="text/javascript" charset="utf-8" src="../javascripts/json2.js"></script>
-    <script type="text/javascript" charset="utf-8" src="https://rawgithub.com/Constellation/doctrine/master/doctrine.js"></script>
+    <script type="text/javascript" charset="utf-8" src="../javascripts/doctrine.js"></script>
     <script type="text/javascript" charset="utf-8">
     $(function() {
       var code = [


### PR DESCRIPTION
This makes gh-pages demo work again. I understand that it points to older doctrine.js, but it is a nice exploratory tool, and is better than current "doctrine not found" experience.

Real solution would be to add browserify script to doctrine#master, then check that generated script to gh-pages. My naive attempt to do this did not work, still a browserify newbie.